### PR TITLE
Configure deployment to Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,19 @@ npm run dev
 - Gemini APIキーが設定されていない場合、デモデータが表示されます
 - PDFの形式によっては、抽出精度が異なる場合があります
 - 抽出されたデータは必ず確認・検証してからご使用ください
+
+## Deployment
+
+This project is configured for deployment to Cloudflare Pages.
+
+To deploy the application:
+
+1.  **Build the project:**
+    ```bash
+    npm run build
+    ```
+2.  **Deploy to Cloudflare Pages:**
+    ```bash
+    npm run deploy
+    ```
+    This command uses `wrangler` to deploy the contents of the `./dist` directory. Ensure you have `wrangler` installed and configured (`npm install -D wrangler` is already done for this project). You will need to be logged into your Cloudflare account via `wrangler login`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "wrangler pages deploy ./dist"
   },
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
@@ -30,6 +31,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "wrangler": "^4.20.0"
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,15 @@
+name = "vite-react-typescript-starter"
+compatibility_date = "2024-07-16" # Assuming today's date for compatibility
+
+# Configure for deploying a static site (Cloudflare Pages)
+[pages]
+# The directory containing your static assets.
+# It should be the output directory of your build command.
+assets.directory = "./dist"
+
+# Optional: Configure a custom build command if needed
+# pages_build_output_dir = "./dist" # Already defaults to looking for standard framework dirs like dist, public, _site etc.
+
+# Optional: Include or exclude files from the deployment
+# assets.include = ["*.html", "*.css", "*.js"]
+# assets.exclude = ["node_modules/*"]


### PR DESCRIPTION
This commit introduces the necessary configuration to deploy the Vite application to Cloudflare Pages.

Changes include:
- Added `wrangler.toml` to define the project name, compatibility date, and specify the static assets directory (`./dist`) for Cloudflare Pages.
- Added `wrangler` (v4.20.0) as a devDependency to ensure it's available in the build environment.
- Added a `deploy` script to `package.json` (`wrangler pages deploy ./dist`) for easy deployment.
- Updated `README.md` with instructions on how to build and deploy the application to Cloudflare Pages.

These changes address the previous deployment error `Missing entry-point to Worker script or to assets directory` by providing a clear configuration for Wrangler.